### PR TITLE
Hotfix/ajax redirect

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -563,7 +563,7 @@ class cf7_extras {
 			$redirect = trim( $this->get_form_settings( $form, 'redirect-success' ) );
 
 			if ( ! empty( $redirect ) ) {
-				wp_redirect( esc_url_raw( $redirect ) );
+				wp_safe_redirect( esc_url_raw( $redirect ) );
 				exit;
 			}
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -563,7 +563,7 @@ class cf7_extras {
 			$redirect = trim( $this->get_form_settings( $form, 'redirect-success' ) );
 
 			if ( ! empty( $redirect ) ) {
-				wp_safe_redirect( esc_url_raw( $redirect ) );
+				wp_safe_redirect( esc_url_raw( $redirect ), 302 );
 				exit;
 			}
 		}


### PR DESCRIPTION
wp_redirect function doesn't work since the default status parameter value somewhere updates to 200 and it doesn't trigger redirection, so using the wp_safe_redirect function and calling with 302 status code parameter can solve this issue.

related to #5 