### PR TITLE
Add Matomo (formerly Piwik) event tracking setting alongside Google Analytics event tracking

### DIFF
--- a/js/controls.js
+++ b/js/controls.js
@@ -45,6 +45,9 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Sent', formConfig.title );
+		}
+		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
+			var formConfig = getFormConfig( form.contactFormId );
 			trackMatomoEvent( 'Contact Form', 'Sent', formConfig.title );
 		}
 	} );
@@ -53,6 +56,9 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Error', formConfig.title );
+		}
+		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
+			var formConfig = getFormConfig( form.contactFormId );
 			trackMatomoEvent( 'Contact Form', 'Error', formConfig.title );
 		}
 	} );
@@ -61,6 +67,9 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Spam', formConfig.title );
+		}
+		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
+			var formConfig = getFormConfig( form.contactFormId );
 			trackMatomoEvent( 'Contact Form', 'Spam', formConfig.title );
 		}
 	} );
@@ -69,6 +78,9 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Submit', formConfig.title );
+		}
+		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
+			var formConfig = getFormConfig( form.contactFormId );
 			trackMatomoEvent( 'Contact Form', 'Submit', formConfig.title );
 		}
 

--- a/js/controls.js
+++ b/js/controls.js
@@ -11,6 +11,12 @@
 		}
 	};
 
+	var trackMatomoEvent = function( eventCategory, eventAction, eventTitle ) {
+		if ( 'undefined' !== typeof _paq ) {
+			_paq.push([ 'trackEvent', eventCategory, eventAction, eventTitle ]);
+		}
+	};
+
 	var formEventEnabled = function( formId, eventName ) {
 		formId = parseInt( formId );
 
@@ -39,6 +45,7 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Sent', formConfig.title );
+			trackMatomoEvent( 'Contact Form', 'Sent', formConfig.title );
 		}
 	} );
 
@@ -46,6 +53,7 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Error', formConfig.title );
+			trackMatomoEvent( 'Contact Form', 'Error', formConfig.title );
 		}
 	} );
 
@@ -53,6 +61,7 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Spam', formConfig.title );
+			trackMatomoEvent( 'Contact Form', 'Spam', formConfig.title );
 		}
 	} );
 
@@ -60,6 +69,7 @@
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
 			trackGaEvent( 'Contact Form', 'Submit', formConfig.title );
+			trackMatomoEvent( 'Contact Form', 'Submit', formConfig.title );
 		}
 
 		if ( form.contactFormId && 'mail_sent' === form.status && formEventEnabled( form.contactFormId, 'redirect-success' ) ) {

--- a/js/controls.js
+++ b/js/controls.js
@@ -3,16 +3,13 @@
 		return;
 	}
 
-	var trackGaEvent = function( eventCategory, eventAction, eventTitle ) {
-		if ( 'function' === typeof ga ) {
+	var trackAnalyticsEvent = function( eventCategory, eventAction, eventTitle ) {
+		if ( 'function' === typeof ga ) { // Universal Google Analytics is available
 			ga( 'send', 'event', eventCategory, eventAction, eventTitle );
-		} else if ( 'undefined' !== typeof _gaq ) {
+		} else if ( 'undefined' !== typeof _gaq ) { // Classic Google Analytics is available
 			_gaq.push( [ '_trackEvent', eventCategory, eventAction, eventTitle ] );
 		}
-	};
-
-	var trackMatomoEvent = function( eventCategory, eventAction, eventTitle ) {
-		if ( 'undefined' !== typeof _paq ) {
+		if ( 'undefined' !== typeof _paq ) { // Matomo (formerly Piwik) is available
 			_paq.push([ 'trackEvent', eventCategory, eventAction, eventTitle ]);
 		}
 	};
@@ -44,44 +41,28 @@
 	$( document ).on( 'wpcf7:mailsent', function( event, form ) {
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
-			trackGaEvent( 'Contact Form', 'Sent', formConfig.title );
-		}
-		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
-			var formConfig = getFormConfig( form.contactFormId );
-			trackMatomoEvent( 'Contact Form', 'Sent', formConfig.title );
+			trackAnalyticsEvent( 'Contact Form', 'Sent', formConfig.title );
 		}
 	} );
 
 	$( document ).on( 'wpcf7:mailfailed', function( event, form ) {
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
-			trackGaEvent( 'Contact Form', 'Error', formConfig.title );
-		}
-		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
-			var formConfig = getFormConfig( form.contactFormId );
-			trackMatomoEvent( 'Contact Form', 'Error', formConfig.title );
+			trackAnalyticsEvent( 'Contact Form', 'Error', formConfig.title );
 		}
 	} );
 
 	$( document ).on( 'wpcf7:spam', function( event, form ) {
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
-			trackGaEvent( 'Contact Form', 'Spam', formConfig.title );
-		}
-		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
-			var formConfig = getFormConfig( form.contactFormId );
-			trackMatomoEvent( 'Contact Form', 'Spam', formConfig.title );
+			trackAnalyticsEvent( 'Contact Form', 'Spam', formConfig.title );
 		}
 	} );
 
 	$( document ).on( 'wpcf7:submit', function( event, form ) {
 		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-ga' ) ) {
 			var formConfig = getFormConfig( form.contactFormId );
-			trackGaEvent( 'Contact Form', 'Submit', formConfig.title );
-		}
-		if ( form.contactFormId && formEventEnabled( form.contactFormId, 'track-matomo' ) ) {
-			var formConfig = getFormConfig( form.contactFormId );
-			trackMatomoEvent( 'Contact Form', 'Submit', formConfig.title );
+			trackAnalyticsEvent( 'Contact Form', 'Submit', formConfig.title );
 		}
 
 		if ( form.contactFormId && 'mail_sent' === form.status && formEventEnabled( form.contactFormId, 'redirect-success' ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -105,7 +105,7 @@ class cf7_extras {
 				'docs_url' => 'http://contactform7.com/controlling-behavior-by-setting-constants/',
 				'field' => sprintf(
 					'<label>
-						<input id="extra-disable-ajax" data-toggle-on=".extra-field-extra-track-ga, .extra-field-extra-track-matomo, #extra-html5-fallback-wrap" name="extra[disable-ajax]" value="1" %s type="checkbox" />
+						<input id="extra-disable-ajax" data-toggle-on=".extra-field-extra-track-ga, #extra-html5-fallback-wrap" name="extra[disable-ajax]" value="1" %s type="checkbox" />
 						<span>%s</span>
 					</label>
 					<p class="desc">%s</p>',
@@ -197,7 +197,7 @@ class cf7_extras {
 				)
 			),
 			'extra-track-ga' => array(
-				'label' => __( 'Google Analytics Tracking', 'cf7-extras' ),
+				'label' => __( 'Google Analytics and/or Matomo (formerly Piwik) Tracking', 'cf7-extras' ),
 				'docs_url' => 'http://contactform7.com/tracking-form-submissions-with-google-analytics/',
 				'field' => sprintf(
 					'<label>
@@ -206,24 +206,7 @@ class cf7_extras {
 					</label>
 					<p class="desc">%s</p>',
 					checked( $settings[ 'track-ga' ], true, false ),
-					esc_html__( 'Trigger Google Analytics events on form submissions.', 'cf7-extras' ),
-					esc_html( sprintf(
-						__( 'Track form submissions as events with category "Contact Form", actions "Sent", "Error" or "Submit" and label "%s".', 'cf7-extras' ),
-						$cf7->title()
-					) )
-				)
-			),
-			'extra-track-matomo' => array(
-				'label' => __( 'Matomo (formerly Piwik) Tracking', 'cf7-extras' ),
-				'docs_url' => 'http://contactform7.com/tracking-form-submissions-with-google-analytics/',
-				'field' => sprintf(
-					'<label>
-						<input type="checkbox" id="extra-track-matomo" name="extra[track-matomo]" value="1" %s />
-						<span>%s</span>
-					</label>
-					<p class="desc">%s</p>',
-					checked( $settings[ 'track-matomo' ], true, false ),
-					esc_html__( 'Trigger Matomo (formerly Piwik) events on form submissions.', 'cf7-extras' ),
+					esc_html__( 'Trigger Google Analytics and/or Matomo (formerly Piwik) events on form submissions. This will tigger whichever tracking code is set up on the site.', 'cf7-extras' ),
 					esc_html( sprintf(
 						__( 'Track form submissions as events with category "Contact Form", actions "Sent", "Error" or "Submit" and label "%s".', 'cf7-extras' ),
 						$cf7->title()
@@ -421,7 +404,6 @@ class cf7_extras {
 				'track-ga-success' => false,
 				'track-ga-submit' => false,
 				'track-ga' => false,
-				'track-matomo' => false,
 				'google-recaptcha-lang' => null,
 			)
 		);
@@ -511,7 +493,6 @@ class cf7_extras {
 
 		$form_events = array(
 			'track-ga' => array(),
-			'track-matomo' => array(),
 			'redirect-success' => array(),
 		);
 

--- a/plugin.php
+++ b/plugin.php
@@ -105,7 +105,7 @@ class cf7_extras {
 				'docs_url' => 'http://contactform7.com/controlling-behavior-by-setting-constants/',
 				'field' => sprintf(
 					'<label>
-						<input id="extra-disable-ajax" data-toggle-on=".extra-field-extra-track-ga, #extra-html5-fallback-wrap" name="extra[disable-ajax]" value="1" %s type="checkbox" />
+						<input id="extra-disable-ajax" data-toggle-on=".extra-field-extra-track-ga, .extra-field-extra-track-matomo, #extra-html5-fallback-wrap" name="extra[disable-ajax]" value="1" %s type="checkbox" />
 						<span>%s</span>
 					</label>
 					<p class="desc">%s</p>',
@@ -207,6 +207,23 @@ class cf7_extras {
 					<p class="desc">%s</p>',
 					checked( $settings[ 'track-ga' ], true, false ),
 					esc_html__( 'Trigger Google Analytics events on form submissions.', 'cf7-extras' ),
+					esc_html( sprintf(
+						__( 'Track form submissions as events with category "Contact Form", actions "Sent", "Error" or "Submit" and label "%s".', 'cf7-extras' ),
+						$cf7->title()
+					) )
+				)
+			),
+			'extra-track-matomo' => array(
+				'label' => __( 'Matomo (formerly Piwik) Tracking', 'cf7-extras' ),
+				'docs_url' => 'http://contactform7.com/tracking-form-submissions-with-google-analytics/',
+				'field' => sprintf(
+					'<label>
+						<input type="checkbox" id="extra-track-matomo" name="extra[track-matomo]" value="1" %s />
+						<span>%s</span>
+					</label>
+					<p class="desc">%s</p>',
+					checked( $settings[ 'track-matomo' ], true, false ),
+					esc_html__( 'Trigger Matomo (formerly Piwik) events on form submissions.', 'cf7-extras' ),
 					esc_html( sprintf(
 						__( 'Track form submissions as events with category "Contact Form", actions "Sent", "Error" or "Submit" and label "%s".', 'cf7-extras' ),
 						$cf7->title()
@@ -404,6 +421,7 @@ class cf7_extras {
 				'track-ga-success' => false,
 				'track-ga-submit' => false,
 				'track-ga' => false,
+				'track-matomo' => false,
 				'google-recaptcha-lang' => null,
 			)
 		);
@@ -493,6 +511,7 @@ class cf7_extras {
 
 		$form_events = array(
 			'track-ga' => array(),
+			'track-matomo' => array(),
 			'redirect-success' => array(),
 		);
 

--- a/plugin.php
+++ b/plugin.php
@@ -197,7 +197,7 @@ class cf7_extras {
 				)
 			),
 			'extra-track-ga' => array(
-				'label' => __( 'Google Analytics and/or Matomo (formerly Piwik) Tracking', 'cf7-extras' ),
+				'label' => __( 'Analytics Tracking', 'cf7-extras' ),
 				'docs_url' => 'http://contactform7.com/tracking-form-submissions-with-google-analytics/',
 				'field' => sprintf(
 					'<label>
@@ -206,7 +206,7 @@ class cf7_extras {
 					</label>
 					<p class="desc">%s</p>',
 					checked( $settings[ 'track-ga' ], true, false ),
-					esc_html__( 'Trigger Google Analytics and/or Matomo (formerly Piwik) events on form submissions. This will tigger whichever tracking code is set up on the site.', 'cf7-extras' ),
+					esc_html__( 'Trigger Google Analytics and/or Matomo (formerly Piwik) events on form submissions. This will tigger the tracking code that has been set up on the site.', 'cf7-extras' ),
 					esc_html( sprintf(
 						__( 'Track form submissions as events with category "Contact Form", actions "Sent", "Error" or "Submit" and label "%s".', 'cf7-extras' ),
 						$cf7->title()


### PR DESCRIPTION
Why limit this plugin to just offering Google Analytics? There are sites that either can't (behind Chinese firewall) or don't use Google Analytics and/or have different platforms being used for supplemental stats.

This patch adds a setting alongside the Google Analytics event tracking for enabling Matomo (formerly Piwik) event tracking as desired. I would love to see this officially supported as this is a leading alternative to Google Analytics that has potential use cases & users that would benefit from it.

As an aside, I've also posted about this on the WordPress.org forum at: https://wordpress.org/support/topic/proposed-patch-add-matomo-formerly-piwik-event-tracking-support/